### PR TITLE
Remove authors from pdf properties when in review mode

### DIFF
--- a/vgtc.cls
+++ b/vgtc.cls
@@ -320,7 +320,7 @@
   \hypersetup{
     pdfpagemode=UseNone,
     pdftitle={\@title},
-    pdfauthor={\@author},
+    pdfauthor={\iftoggle{vgtc@review}{anonymous authors}{\@author}},
     pdfsubject={VGTC Special Issue Paper for TVCG},
     pdfkeywords={\vgtc@keywords},
     pageanchor=true,


### PR DESCRIPTION
Right now, documents submitted for review carry the authors' names in the pdf properties (assuming that `\author` is set, which most authors will do). That heavily subverts double-blindness.

This fix replaces the author property with `anonymous authors` when review mode is set.