### PR TITLE
Display title in document viewer automatically

### DIFF
--- a/vgtc.cls
+++ b/vgtc.cls
@@ -339,7 +339,8 @@
     citecolor=NavyBlue,
     anchorcolor=black,      % changing this colors te teaser caption using dvips
     nesting=true,
-    linktocpage}
+    linktocpage,
+    pdfdisplaydoctitle}
   \ifpdf%                   % if we use pdflatex
   \else%                    % else we use pure latex
     \renewcommand{\pdfbookmark}[3][]{}


### PR DESCRIPTION
Some pdf viewers default to displaying the pdf document's file name (template.pdf) and not the document's title (Global Illumination for Fun and Profit), e.g. Adobe Acrobat, at least on Windows. 

This PR adds an option for the hyperref package which indicates that the document title instead of file name should be displayed.