### PR TITLE
Whitespace and capitilization fixes

### DIFF
--- a/README
+++ b/README
@@ -32,7 +32,7 @@ pictures/       - subdirectory with sample images, both in EPS and in direct pix
 Usage
 =====
 
-The template can be used with an established LaTeX environment by calling pdfLaTeX or LaTex. For online collaborative editing or without a local LaTeX installation, one option is to use https://www.overleaf.com/. For Windows-based LaTeX installations you can use, for example, the environment provided by http://www.texniccenter.org/ along with MikTeX (http://miktex.org/). For Unix-based installations, please use your favorite LaTeX distribution and editing environment or use the makefile following the instructions below.
+The template can be used with an established LaTeX environment by calling pdfLaTeX or LaTeX. For online collaborative editing or without a local LaTeX installation, one option is to use https://www.overleaf.com/. For Windows-based LaTeX installations you can use, for example, the environment provided by http://www.texniccenter.org/ along with MikTeX (http://miktex.org/). For Unix-based installations, please use your favorite LaTeX distribution and editing environment or use the makefile following the instructions below.
 
 Use of the Makefile
 ===================
@@ -77,11 +77,11 @@ The included makefile also allows you to run each step of the process manually. 
    PostScript file.
 
  "make pdf"
-   This will process the .tex file using pdfTeX/pdflatex to produce a PDF
+   This will process the .tex file using pdfTeX/pdfLaTeX to produce a PDF
    file directly (not using a DVI and PostScript file).
    Please make sure that all fonts are embedded.
    You can use pdffonts my_document.pdf to check if they are.
-   It is standard in all modern latex distributions.
+   It is standard in all modern LaTeX distributions.
    If you use eps figures (e.g. R or gnuplot figures) which you convert to
    PDF using epstopdf, do the following:
    Use GL_OPTIONS, a global environment variable for ghostscript:

--- a/README
+++ b/README
@@ -56,7 +56,7 @@ or manually, if the makefile does not work for you
 
 If you run 'make' for the first time, a successful compilation will create a file called 'template.pdf'. Please make sure, that its layout is identical to the file 'template-journal.pdf' provided with this package.
 
-The included makefile also allows you to run each step of the process manually.  Below are a list of available options that may be passed to make
+The included makefile also allows you to run each step of the process manually. Below are a list of available options that may be passed to make
 
  "make clean"
    removes all files that can be generated automatically.
@@ -68,7 +68,7 @@ The included makefile also allows you to run each step of the process manually. 
    This will perform all functions to build a proper paper using GhostScript 8.
 
  "make dvi"
-   This will process the .tex file and produce a DVI output file.  This
+   This will process the .tex file and produce a DVI output file. This
    step may process the .tex file several times to process all references
    and citations.
 

--- a/makefile
+++ b/makefile
@@ -52,7 +52,7 @@ DVIPS = dvips
 RERUN = "(There were undefined references|Rerun to get (cross-references|the bars) right)"
 RERUNBIB = "No file.*\.bbl|Citation.*undefined" 
 
-PSFILES  = $(DVIFILES:.dvi=.ps) 
+PSFILES = $(DVIFILES:.dvi=.ps) 
 
 PDFFILES7 = $(DVIFILES:.dvi=.pdf7) 
 PDFFILES8 = $(DVIFILES:.dvi=.pdf8) 
@@ -112,7 +112,7 @@ $(MAINTEXFILE) : $(SUBTEXFILES) $(BIBFILES)
 				egrep -i "(Reference|Citation).*undefined" $*.log ; true
 
 %.ps:			%.dvi
-#				dvips -T 7.875in,10.75in -Ppdf -G0 $< -o $@  #use tvcgpapersize
+#				dvips -T 7.875in,10.75in -Ppdf -G0 $< -o $@ #use tvcgpapersize
 #				dvips -Ppdf -G0 $< -o $@
 				dvips $(DVIPSPAPERSIZE) -Pdownload35 -Ppdf -G0 $< -o $@
 #				dvips $< -o $@

--- a/template.tex
+++ b/template.tex
@@ -327,7 +327,7 @@ An example of the reference formatting is provided in the \textbf{References} se
 
 \subsection{Include DOIs}
 
-All references which have a DOI should have it included in the bib\TeX\ for the style to display.
+All references which have a DOI should have it included in the Bib\TeX\ for the style to display.
 The DOI can be entered with or without the \url{https://doi.org/} prefix.
 
 \subsection{Narrow DOI option}
@@ -342,18 +342,18 @@ DVI-based processes to compile the template apparently cannot handle the differe
 \subsection{Disabling hyperlinks}
 
 To avoid adding hyperlinks to the references (the default) you can use \verb|\bibliographystyle{abbrv-doi}| instead of \verb|\bibliographystyle{abbrv-doi-hyperref}|.
-By default, the DOI field in a bib\TeX\ entry is turned into a hyperlink.
+By default, the DOI field in a Bib\TeX\ entry is turned into a hyperlink.
 
-See the examples in the bib\TeX\ file and the bibliography at the end of this template.
+See the examples in the Bib\TeX\ file and the bibliography at the end of this template.
 
-\subsection{Guidelines for bibTeX}
+\subsection{Guidelines for BibTeX}
 
 \begin{itemize}
   \item All bibliographic entries should be sorted alphabetically by the last name of the first author.
-        This \LaTeX/bib\TeX\ template takes care of this sorting automatically.
+        This \LaTeX/Bib\TeX\ template takes care of this sorting automatically.
   \item Merge multiple references into one; e.\,g., use \cite{Max1995OpticalModelsDirect,Kitware2003VisualizationToolkitUsers} (not \cite{Kitware2003VisualizationToolkitUsers}\cite{Max1995OpticalModelsDirect}).
         Within each set of multiple references, the references should be sorted in ascending order.
-        This \LaTeX/bib\TeX\ template takes care of both the merging and the sorting automatically.
+        This \LaTeX/Bib\TeX\ template takes care of both the merging and the sorting automatically.
   \item Verify all data obtained from digital libraries, even ACM's DL and IEEE Xplore etc.\ are sometimes wrong or incomplete.
   \item Do not trust bibliographic data from other services such as Mendeley.com, Google Scholar, or similar; these are even more likely to be incorrect or incomplete.
   \item Articles in journal---items to include:
@@ -474,7 +474,7 @@ Note that your error is due to packages you use that define \verb|\ifpdf| which 
 
 \subsection{\texttt{pdfendlink} error}
 
-Occasionally (for some \LaTeX\ distributions) this hyper-linked bib\TeX\ style may lead to \textbf{compilation errors} (\texttt{pdfendlink ended up in different nesting level ...}) if a reference entry is broken across two pages (due to a bug in \verb|hyperref|).
+Occasionally (for some \LaTeX\ distributions) this hyper-linked Bib\TeX\ style may lead to \textbf{compilation errors} (\texttt{pdfendlink ended up in different nesting level ...}) if a reference entry is broken across two pages (due to a bug in \verb|hyperref|).
 In this case, make sure you have the latest version of the \verb|hyperref| package (i.e.\ update your \LaTeX\ installation/packages) or, alternatively, revert back to \verb|\bibliographystyle{abbrv-doi}| (at the expense of removing hyperlinks from the bibliography) and try \verb|\bibliographystyle{abbrv-doi-hyperref}| again after some more editing.
 
 \end{document}

--- a/template.tex
+++ b/template.tex
@@ -20,7 +20,7 @@
 %\preprinttext{To appear in IEEE Transactions on Visualization and Computer Graphics.}
 
 %% In preprint mode, this adds a link to the version of the paper on IEEEXplore
-%% Uncomment this line when you produce a preprint version of the article 
+%%
 %% after the article receives a DOI for the paper from IEEE
 %\ieeedoi{xx.xxxx/TVCG.201x.xxxxxxx}
 
@@ -44,7 +44,7 @@
 %% Include only the 16-digit dashed ID.
 \author{%
   \authororcid{Josiah S.\ Carberry}{0000-0002-1825-0097},
-  Ed Grimley, and 
+  Ed
   Martha Stewart
 }
 
@@ -295,7 +295,7 @@ Tables, such as \cref{tab:vis_papers} can also be included.
     1992 & 53 &   &    &    &    &    &    &  53 &  53 \\
     1991 & 50 &   &    &    &    &    &    &  50 &  50 \\
     1990 & 53 &   &    &    &    &    &    &  53 &  53 \\
-    \midrule               
+    \midrule
     \textbf{sum} & \textbf{1545} & \textbf{9} & \textbf{632} & \textbf{310} & \textbf{50} & \textbf{123} & \textbf{25} & \textbf{2694} & \textbf{2546} \\
     \bottomrule
   \end{tabu}%
@@ -404,7 +404,7 @@ You can use the \verb|hideappendix| class option to remove everything after \ver
 We encourage you to submit a full version of your paper to a preprint server with any appendices included.
 
 You can use the \verb|\iflabelexists| macro to cross reference an appendix from the main text, but only if that label (i.e.\ the appendix) actually exists.
-For example, above we use 
+For
 
 \begin{verbatim}
 \iflabelexists{appendix:troubleshooting}

--- a/template.tex
+++ b/template.tex
@@ -51,15 +51,15 @@
 \authorfooter{
   %% insert punctuation at end of each item
   \item
-  	Josiah Carberry is with Brown University.
-  	E-mail: jcarberry@example.com
+    Josiah Carberry is with Brown University.
+    E-mail: jcarberry@example.com
   \item
-  	Ed Grimley is with Grimley Widgets, Inc.
-  	E-mail: ed.grimley@example.com.
+    Ed Grimley is with Grimley Widgets, Inc.
+    E-mail: ed.grimley@example.com.
 
   \item Martha Stewart is with Martha Stewart Enterprises at Microsoft
   Research.
-  	E-mail: martha.stewart@example.com.
+    E-mail: martha.stewart@example.com.
 }
 
 %% Abstract section.
@@ -80,8 +80,8 @@
   \centering
   \includegraphics[width=\linewidth, alt={A view of a city with buildings peeking out of the clouds.}]{CypressView}
   \caption{%
-  	In the Clouds: Vancouver from Cypress Mountain.
-  	Note that the teaser may not be wider than the abstract block.%
+    In the Clouds: Vancouver from Cypress Mountain.
+    Note that the teaser may not be wider than the abstract block.%
   }
   \label{fig:teaser}
 }
@@ -209,24 +209,24 @@ Note that \verb|\subref| only works for one label at a time.
 \begin{figure}[tbp]
   \centering
   \begin{subfigure}[b]{0.45\columnwidth}
-  	\centering
-  	\includegraphics[width=\textwidth, alt={Big letter A on a gray background.}]{example-image-a}
-  	\caption{The letter A.}
-  	\label{fig:ex_subfigs_a}
+    \centering
+    \includegraphics[width=\textwidth, alt={Big letter A on a gray background.}]{example-image-a}
+    \caption{The letter A.}
+    \label{fig:ex_subfigs_a}
   \end{subfigure}%
   \hfill%
   \begin{subfigure}[b]{0.45\columnwidth}
-  	\centering
-  	\includegraphics[width=\textwidth, alt={Big letter B on a gray background.}]{example-image-b}
-  	\caption{The letter B.}
-  	\label{fig:ex_subfigs_b}
+    \centering
+    \includegraphics[width=\textwidth, alt={Big letter B on a gray background.}]{example-image-b}
+    \caption{The letter B.}
+    \label{fig:ex_subfigs_b}
   \end{subfigure}%
   \\%
   \begin{subfigure}[b]{0.45\columnwidth}
-  	\centering
-  	\includegraphics[width=\textwidth, alt={Big letter C on a gray background.}]{example-image-c}
-  	\caption{The letter C.}
-  	\label{fig:ex_subfigs_c}
+    \centering
+    \includegraphics[width=\textwidth, alt={Big letter C on a gray background.}]{example-image-c}
+    \caption{The letter C.}
+    \label{fig:ex_subfigs_c}
   \end{subfigure}%
   \subfigsCaption{Example of adding subfigures with the \texttt{subcaption} package.}
   \label{fig:ex_subfigs}
@@ -255,49 +255,49 @@ Tables, such as \cref{tab:vis_papers} can also be included.
 
 \begin{table}[tb]
   \caption{%
-  	VIS/VisWeek accepted/presented papers: 1990--2016.%
+    VIS/VisWeek accepted/presented papers: 1990--2016.%
   }
   \label{tab:vis_papers}
   \scriptsize%
   \centering%
   \begin{tabu}{%
-  	  r%
-  	  	*{7}{c}%
-  	  	*{2}{r}%
-  	}
-  	\toprule
-  	year & \rotatebox{90}{Vis/SciVis} & \rotatebox{90}{SciVis conf} & \rotatebox{90}{InfoVis} & \rotatebox{90}{VAST} & \rotatebox{90}{VAST conf} & \rotatebox{90}{TVCG @ VIS} & \rotatebox{90}{CG\&A @ VIS} & \rotatebox{90}{VIS/VisWeek} \rotatebox{90}{incl.\ TVCG/CG\&A} & \rotatebox{90}{VIS/VisWeek} \rotatebox{90}{w/o TVCG/CG\&A} \\
-  	\midrule
-  	2016 & 30 &   & 37 & 33 & 15 & 23 & 10 & 148 & 115 \\
-  	2015 & 33 & 9 & 38 & 33 & 14 & 17 & 15 & 159 & 127 \\
-  	2014 & 34 &   & 45 & 33 & 21 & 20 &    & 153 & 133 \\
-  	2013 & 31 &   & 38 & 32 &    & 20 &    & 121 & 101 \\
-  	2012 & 42 &   & 44 & 30 &    & 23 &    & 139 & 116 \\
-  	2011 & 49 &   & 44 & 26 &    & 20 &    & 139 & 119 \\
-  	2010 & 48 &   & 35 & 26 &    &    &    & 109 & 109 \\
-  	2009 & 54 &   & 37 & 26 &    &    &    & 117 & 117 \\
-  	2008 & 50 &   & 28 & 21 &    &    &    &  99 &  99 \\
-  	2007 & 56 &   & 27 & 24 &    &    &    & 107 & 107 \\
-  	2006 & 63 &   & 24 & 26 &    &    &    & 113 & 113 \\
-  	2005 & 88 &   & 31 &    &    &    &    & 119 & 119 \\
-  	2004 & 70 &   & 27 &    &    &    &    &  97 &  97 \\
-  	2003 & 74 &   & 29 &    &    &    &    & 103 & 103 \\
-  	2002 & 78 &   & 23 &    &    &    &    & 101 & 101 \\
-  	2001 & 74 &   & 22 &    &    &    &    &  96 &  96 \\
-  	2000 & 73 &   & 20 &    &    &    &    &  93 &  93 \\
-  	1999 & 69 &   & 19 &    &    &    &    &  88 &  88 \\
-  	1998 & 72 &   & 18 &    &    &    &    &  90 &  90 \\
-  	1997 & 72 &   & 16 &    &    &    &    &  88 &  88 \\
-  	1996 & 65 &   & 12 &    &    &    &    &  77 &  77 \\
-  	1995 & 56 &   & 18 &    &    &    &    &  74 &  74 \\
-  	1994 & 53 &   &    &    &    &    &    &  53 &  53 \\
-  	1993 & 55 &   &    &    &    &    &    &  55 &  55 \\
-  	1992 & 53 &   &    &    &    &    &    &  53 &  53 \\
-  	1991 & 50 &   &    &    &    &    &    &  50 &  50 \\
-  	1990 & 53 &   &    &    &    &    &    &  53 &  53 \\
-  	\midrule               
-  	\textbf{sum} & \textbf{1545} & \textbf{9} & \textbf{632} & \textbf{310} & \textbf{50} & \textbf{123} & \textbf{25} & \textbf{2694} & \textbf{2546} \\
-  	\bottomrule
+      r%
+        *{7}{c}%
+        *{2}{r}%
+    }
+    \toprule
+    year & \rotatebox{90}{Vis/SciVis} & \rotatebox{90}{SciVis conf} & \rotatebox{90}{InfoVis} & \rotatebox{90}{VAST} & \rotatebox{90}{VAST conf} & \rotatebox{90}{TVCG @ VIS} & \rotatebox{90}{CG\&A @ VIS} & \rotatebox{90}{VIS/VisWeek} \rotatebox{90}{incl.\ TVCG/CG\&A} & \rotatebox{90}{VIS/VisWeek} \rotatebox{90}{w/o TVCG/CG\&A} \\
+    \midrule
+    2016 & 30 &   & 37 & 33 & 15 & 23 & 10 & 148 & 115 \\
+    2015 & 33 & 9 & 38 & 33 & 14 & 17 & 15 & 159 & 127 \\
+    2014 & 34 &   & 45 & 33 & 21 & 20 &    & 153 & 133 \\
+    2013 & 31 &   & 38 & 32 &    & 20 &    & 121 & 101 \\
+    2012 & 42 &   & 44 & 30 &    & 23 &    & 139 & 116 \\
+    2011 & 49 &   & 44 & 26 &    & 20 &    & 139 & 119 \\
+    2010 & 48 &   & 35 & 26 &    &    &    & 109 & 109 \\
+    2009 & 54 &   & 37 & 26 &    &    &    & 117 & 117 \\
+    2008 & 50 &   & 28 & 21 &    &    &    &  99 &  99 \\
+    2007 & 56 &   & 27 & 24 &    &    &    & 107 & 107 \\
+    2006 & 63 &   & 24 & 26 &    &    &    & 113 & 113 \\
+    2005 & 88 &   & 31 &    &    &    &    & 119 & 119 \\
+    2004 & 70 &   & 27 &    &    &    &    &  97 &  97 \\
+    2003 & 74 &   & 29 &    &    &    &    & 103 & 103 \\
+    2002 & 78 &   & 23 &    &    &    &    & 101 & 101 \\
+    2001 & 74 &   & 22 &    &    &    &    &  96 &  96 \\
+    2000 & 73 &   & 20 &    &    &    &    &  93 &  93 \\
+    1999 & 69 &   & 19 &    &    &    &    &  88 &  88 \\
+    1998 & 72 &   & 18 &    &    &    &    &  90 &  90 \\
+    1997 & 72 &   & 16 &    &    &    &    &  88 &  88 \\
+    1996 & 65 &   & 12 &    &    &    &    &  77 &  77 \\
+    1995 & 56 &   & 18 &    &    &    &    &  74 &  74 \\
+    1994 & 53 &   &    &    &    &    &    &  53 &  53 \\
+    1993 & 55 &   &    &    &    &    &    &  55 &  55 \\
+    1992 & 53 &   &    &    &    &    &    &  53 &  53 \\
+    1991 & 50 &   &    &    &    &    &    &  50 &  50 \\
+    1990 & 53 &   &    &    &    &    &    &  53 &  53 \\
+    \midrule               
+    \textbf{sum} & \textbf{1545} & \textbf{9} & \textbf{632} & \textbf{310} & \textbf{50} & \textbf{123} & \textbf{25} & \textbf{2694} & \textbf{2546} \\
+    \bottomrule
   \end{tabu}%
 \end{table}
 
@@ -305,7 +305,7 @@ Tables, such as \cref{tab:vis_papers} can also be included.
   \centering % avoid the use of \begin{center}...\end{center} and use \centering instead (more compact)
   \includegraphics[width=\columnwidth, alt={A line graph showing paper counts between 0 and 160 from 1990 to 2016 for 9 venues.}]{paper-count-2016}
   \caption{%
-  	A visualization of the 1990--2016 data from \cref{tab:vis_papers}, recreated based on Fig.\ 1 from \cite{Isenberg2017Vispubdata.orgMetadataCollection}.%
+    A visualization of the 1990--2016 data from \cref{tab:vis_papers}, recreated based on Fig.\ 1 from \cite{Isenberg2017Vispubdata.orgMetadataCollection}.%
   }
   \label{fig:vis_papers}
 \end{figure}
@@ -358,23 +358,23 @@ See the examples in the Bib\TeX\ file and the bibliography at the end of this te
   \item Do not trust bibliographic data from other services such as Mendeley.com, Google Scholar, or similar; these are even more likely to be incorrect or incomplete.
   \item Articles in journal---items to include:
         \begin{itemize}
-  	      \item author names
-  	      \item title
-  	      \item journal name
-  	      \item year
-  	      \item volume
-  	      \item number
-  	      \item month of publication as variable name (i.e., \{jan\} for January, etc.; month ranges using \{jan \#\{/\}\# feb\} or \{jan \#\{-{}-\}\# feb\})
+          \item author names
+          \item title
+          \item journal name
+          \item year
+          \item volume
+          \item number
+          \item month of publication as variable name (i.e., \{jan\} for January, etc.; month ranges using \{jan \#\{/\}\# feb\} or \{jan \#\{-{}-\}\# feb\})
           \item series. E.g., ``TVCG``, ``TVCG/VIS`` for special issue VIS papers, ``EuroVis``, ``CGF/EuroVis``.
         \end{itemize}
   \item Use journal names in proper style: correct: ``IEEE Transactions on Visualization and Computer Graphics'', incorrect: ``Visualization and Computer Graphics, IEEE Transactions on''
   \item Papers in proceedings---items to include:
         \begin{itemize}
-  	      \item author names
-  	      \item title
-  	      \item abbreviated proceedings name: e.g., ``Proc.\textbackslash{} CONF\_ACRONYNM'' without the year; example: ``Proc.\textbackslash{} CHI'', ``Proc.\textbackslash{} 3DUI'', ``Proc.\textbackslash{} Eurographics'', ``Proc.\textbackslash{} EuroVis''
-  	      \item year
-  	      \item series. E.g., ``VIS`` and ``EuroVis`` for short papers, ``CHI``...
+          \item author names
+          \item title
+          \item abbreviated proceedings name: e.g., ``Proc.\textbackslash{} CONF\_ACRONYNM'' without the year; example: ``Proc.\textbackslash{} CHI'', ``Proc.\textbackslash{} 3DUI'', ``Proc.\textbackslash{} Eurographics'', ``Proc.\textbackslash{} EuroVis''
+          \item year
+          \item series. E.g., ``VIS`` and ``EuroVis`` for short papers, ``CHI``...
         \end{itemize}
 
   \item Article/paper title convention: refrain from using curly brackets, except for acronyms/proper names/words following dashes/question marks etc.; example:\\\\
@@ -383,8 +383,8 @@ See the examples in the Bib\TeX\ file and the bibliography at the end of this te
         It will then be typeset as ``Marching Cubes: A high resolution 3D surface construction algorithm''.
   \item For all entries:
         \begin{itemize}
-  	      \item DOI can be entered in the DOI field as plain DOI number or as DOI url.
-  	      \item ``pages`` or ``articleno``: Provide full page ranges AA-{}-BB, OR, if an article number is available like recent ACM conferences, use that instead. E.g., see the entry for Panavas et al.\ \cite{Panavas2022JuvenileGraphicalPerception}.
+          \item DOI can be entered in the DOI field as plain DOI number or as DOI url.
+          \item ``pages`` or ``articleno``: Provide full page ranges AA-{}-BB, OR, if an article number is available like recent ACM conferences, use that instead. E.g., see the entry for Panavas et al.\ \cite{Panavas2022JuvenileGraphicalPerception}.
         \end{itemize}
   \item When citing references, do not use the reference as a sentence object; e.g., wrong: ``In \cite{Lorensen1987MarchingCubesHigh} the authors describe \dots'', correct: ``Lorensen and Cline \cite{Lorensen1987MarchingCubesHigh} describe \dots''
 \end{itemize}
@@ -445,7 +445,7 @@ Here are the actual figure credits for this template:
 
 %% if specified like this the section will be omitted in review mode
 \acknowledgments{%
-	The authors wish to thank A, B, and C.
+  The authors wish to thank A, B, and C.
   This work was supported in part by a grant from XYZ (\# 12345-67890).%
 }
 

--- a/template.tex
+++ b/template.tex
@@ -137,7 +137,7 @@ Therefore, \textbf{please leave the copyright statement at the bottom-left of th
 
 \section{Author Details}
 
-You should specify ORCID IDs for each author (see \url{https://orcid.org/}  to register) for disambiguation and long-term contact preservation.
+You should specify ORCID IDs for each author (see \url{https://orcid.org/} to register) for disambiguation and long-term contact preservation.
 Use \verb|\authororcid{Author Name}{0000-0000-0000-0000}| for each author, replacing the ``Author Name'' and using the 16-digit (hyphenated) ORCID ID for the second parameter.
 The template shows an example without ORCID IDs for two of the authors.
 ORCID IDs should be provided in all cases.
@@ -266,7 +266,7 @@ Tables, such as \cref{tab:vis_papers} can also be included.
   	  	*{2}{r}%
   	}
   	\toprule
-  	year & \rotatebox{90}{Vis/SciVis} &   \rotatebox{90}{SciVis conf} &   \rotatebox{90}{InfoVis} &   \rotatebox{90}{VAST} &   \rotatebox{90}{VAST conf} &   \rotatebox{90}{TVCG @ VIS} &   \rotatebox{90}{CG\&A @ VIS} &   \rotatebox{90}{VIS/VisWeek} \rotatebox{90}{incl.\ TVCG/CG\&A}   &   \rotatebox{90}{VIS/VisWeek} \rotatebox{90}{w/o TVCG/CG\&A}   \\
+  	year & \rotatebox{90}{Vis/SciVis} & \rotatebox{90}{SciVis conf} & \rotatebox{90}{InfoVis} & \rotatebox{90}{VAST} & \rotatebox{90}{VAST conf} & \rotatebox{90}{TVCG @ VIS} & \rotatebox{90}{CG\&A @ VIS} & \rotatebox{90}{VIS/VisWeek} \rotatebox{90}{incl.\ TVCG/CG\&A} & \rotatebox{90}{VIS/VisWeek} \rotatebox{90}{w/o TVCG/CG\&A} \\
   	\midrule
   	2016 & 30 &   & 37 & 33 & 15 & 23 & 10 & 148 & 115 \\
   	2015 & 33 & 9 & 38 & 33 & 14 & 17 & 15 & 159 & 127 \\
@@ -354,7 +354,7 @@ See the examples in the bib\TeX\ file and the bibliography at the end of this te
   \item Merge multiple references into one; e.\,g., use \cite{Max1995OpticalModelsDirect,Kitware2003VisualizationToolkitUsers} (not \cite{Kitware2003VisualizationToolkitUsers}\cite{Max1995OpticalModelsDirect}).
         Within each set of multiple references, the references should be sorted in ascending order.
         This \LaTeX/bib\TeX\ template takes care of both the merging and the sorting automatically.
-  \item Verify all data obtained from digital libraries, even ACM's DL and IEEE Xplore  etc.\ are sometimes wrong or incomplete.
+  \item Verify all data obtained from digital libraries, even ACM's DL and IEEE Xplore etc.\ are sometimes wrong or incomplete.
   \item Do not trust bibliographic data from other services such as Mendeley.com, Google Scholar, or similar; these are even more likely to be incorrect or incomplete.
   \item Articles in journal---items to include:
         \begin{itemize}
@@ -379,7 +379,7 @@ See the examples in the bib\TeX\ file and the bibliography at the end of this te
 
   \item Article/paper title convention: refrain from using curly brackets, except for acronyms/proper names/words following dashes/question marks etc.; example:\\\\
         %
-        The paper ``Marching Cubes: A High Resolution 3D Surface Construction Algorithm'' should be entered as ``\{M\}arching \{C\}ubes: A High Resolution \{3D\} Surface Construction Algorithm'' or  ``\{M\}arching \{C\}ubes: A high resolution \{3D\} surface construction algorithm''.
+        The paper ``Marching Cubes: A High Resolution 3D Surface Construction Algorithm'' should be entered as ``\{M\}arching \{C\}ubes: A High Resolution \{3D\} Surface Construction Algorithm'' or ``\{M\}arching \{C\}ubes: A high resolution \{3D\} surface construction algorithm''.
         It will then be typeset as ``Marching Cubes: A high resolution 3D surface construction algorithm''.
   \item For all entries:
         \begin{itemize}

--- a/template.tex
+++ b/template.tex
@@ -20,7 +20,7 @@
 %\preprinttext{To appear in IEEE Transactions on Visualization and Computer Graphics.}
 
 %% In preprint mode, this adds a link to the version of the paper on IEEEXplore
-%%
+%% Uncomment this line when you produce a preprint version of the article
 %% after the article receives a DOI for the paper from IEEE
 %\ieeedoi{xx.xxxx/TVCG.201x.xxxxxxx}
 
@@ -44,7 +44,7 @@
 %% Include only the 16-digit dashed ID.
 \author{%
   \authororcid{Josiah S.\ Carberry}{0000-0002-1825-0097},
-  Ed
+  Ed Grimley, and
   Martha Stewart
 }
 
@@ -404,7 +404,7 @@ You can use the \verb|hideappendix| class option to remove everything after \ver
 We encourage you to submit a full version of your paper to a preprint server with any appendices included.
 
 You can use the \verb|\iflabelexists| macro to cross reference an appendix from the main text, but only if that label (i.e.\ the appendix) actually exists.
-For
+For example, above we use
 
 \begin{verbatim}
 \iflabelexists{appendix:troubleshooting}

--- a/template.tex
+++ b/template.tex
@@ -52,7 +52,7 @@
   %% insert punctuation at end of each item
   \item
     Josiah Carberry is with Brown University.
-    E-mail: jcarberry@example.com
+    E-mail: jcarberry@example.com.
   \item
     Ed Grimley is with Grimley Widgets, Inc.
     E-mail: ed.grimley@example.com.


### PR DESCRIPTION
Hi,

this PR includes some small fixes to whitespace characters and captilization of LaTeX and BibTex. Additionally, one missing period (".") in the `\authorfooter`. A more detailed list:

- fix double spaces
- fix trailing spaces
- replaced tabs with spaces for more consistency
- renamed `bibTex` to `BibTex`
- renamed `latex` variants to `LaTeX`
- added trailing periods to `\authorfooter`. (See [this commit](https://github.com/ieeevgtc/tvcg-journal-latex/pull/16/commits/f549812b19f1f3d6809784392aeca0d63c789784)) Not sure if this is intended as the line above says "insert punctuation at end of each item".

